### PR TITLE
add: フェッチした人口データのキャッシュ機能を追加

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,11 +10,16 @@ import { ChartData } from '../types/chart';
 type PageProps = InferGetServerSidePropsType<typeof getServerSideProps>;
 
 export const Home: NextPage<PageProps> = ({ result }) => {
-  // rechartsへ渡すグラフデータの配列
-  const [chartData, setChartData] = useState<ChartData[]>([]);
+  // RESAS APIから取得した人口データを貯蔵
+  const [storeData, setStoreData] = useState<ChartData[]>([]);
+  // チェックが入っているチェックボックス
+  const [checkCode, setCheckCode] = useState<number[]>([]);
   // データ取得に失敗した都道府県の配列
   const [failures, setFailures] = useState<number[]>([]);
+  // rechartsへ渡すグラフデータの配列
+  const chartData = storeData.filter((data) => checkCode.includes(data.id));
 
+  // チェックボックスをクリックした際の処理
   const handleCheck = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const selected = event.currentTarget; // クリックされた要素
 
@@ -24,41 +29,47 @@ export const Home: NextPage<PageProps> = ({ result }) => {
     const [prefCode, prefName] = selected.value.split(':'); // valueから都道府県コードと名前を取得
     const prefCodeNumber = parseInt(prefCode, 10); // 都道府県コードをnumber型に変換
 
+    const isChartData =
+      storeData.filter((data) => data.id === prefCodeNumber).length !== 0;
     // クリックしたチェックボックスの状態によって処理を振り分ける
-    if (selected.checked) {
-      // チェックが入った場合は、APIから人口推移データを取得し、追加する
-      await fetch(`/api/population?prefCode=${prefCode}`)
-        .then((res) => {
-          if (!res.ok) {
-            throw new Error(`${res.status}: ${res.statusText}`);
-          }
 
-          return res.json();
-        })
-        .then((json) => {
-          // 選択した都道府県が前回データ取得に失敗していた場合、失敗リストから削除
-          if (failures.includes(prefCodeNumber)) {
-            setFailures(
-              failures.filter((failure) => failure !== prefCodeNumber),
-            );
-          }
-          // 取得したデータをrechartsのグラフコンポーネントに渡すデータ配列に追加
-          setChartData([
-            ...chartData,
-            {
-              id: prefCodeNumber,
-              label: prefName,
-              data: json.data,
-            },
-          ]);
-        })
-        .catch(() => {
-          // データ取得に失敗した場合、都道府県を失敗リストへ追加
-          setFailures([...failures, prefCodeNumber]);
-        });
+    if (selected.checked) {
+      setCheckCode([...checkCode, prefCodeNumber]);
+      // チェックが入った場合は、APIから人口推移データを取得し、追加する
+      if (!isChartData) {
+        await fetch(`/api/population?prefCode=${prefCode}`)
+          .then((res) => {
+            if (!res.ok) {
+              throw new Error(`${res.status}: ${res.statusText}`);
+            }
+
+            return res.json();
+          })
+          .then((json) => {
+            // 選択した都道府県が前回データ取得に失敗していた場合、失敗リストから削除
+            if (failures.includes(prefCodeNumber)) {
+              setFailures(
+                failures.filter((failure) => failure !== prefCodeNumber),
+              );
+            }
+            // 取得したデータをrechartsのグラフコンポーネントに渡すデータ配列に追加
+            setStoreData([
+              ...storeData,
+              {
+                id: prefCodeNumber,
+                label: prefName,
+                data: json.data,
+              },
+            ]);
+          })
+          .catch(() => {
+            // データ取得に失敗した場合、都道府県を失敗リストへ追加
+            setFailures([...failures, prefCodeNumber]);
+          });
+      }
     } else {
       // チェックが外れた場合、その都道府県の人口推移データを削除する
-      setChartData(chartData.filter((pref) => pref.label !== prefName));
+      setCheckCode(checkCode.filter((code) => code !== prefCodeNumber));
     }
     // チェックボックスを有効化
     selected.disabled = false;


### PR DESCRIPTION
人口データはAPIから取得したら破棄せずそのまま保持しておく。
チェックが外れ、再度同じチェックボックス にチェックが入れられた場合は、APIからフェッチせず、最初に取得したデータをそのまま使う。

※更新が頻繁なデータはキャッシュの有効期限などを設定すべきだが、今回取得しているデータの更新頻度は年単位なので、とりあえず有効期限の設定は無し。